### PR TITLE
Use a template predicate for polling

### DIFF
--- a/Sources/OSLogClient/Internal/LogPoller.swift
+++ b/Sources/OSLogClient/Internal/LogPoller.swift
@@ -26,6 +26,9 @@ actor LogPoller {
 
     /// Logger instance for any console output.
     private(set) var logger: Logger
+    
+    /// A template predicate used while polling logs
+    private var datePredicate: NSPredicate?
 
     // MARK: - Properties: Computed
     
@@ -82,7 +85,11 @@ actor LogPoller {
         do {
             var predicate: NSPredicate?
             if let lastProcessed {
-                predicate = NSPredicate.init(format: "date > %@", argumentArray: [lastProcessed])
+                if datePredicate == nil {
+                    datePredicate = NSPredicate(format: "date > $DATE")
+                }
+                
+                predicate = datePredicate?.withSubstitutionVariables(["DATE": lastProcessed])
             }
             let items = try logStore.getEntries(matching: predicate).compactMap(validateLogEntry)
             let sortedItems = items.sorted(by: { $0.date <= $1.date })


### PR DESCRIPTION
NSPredicate(format:) will re-parse the format string every time the initializer is called. This is a simple predicate so it's not really that bad, but it's unnecessary. This way the predicate will be parsed once, and subsequent uses will re-use the original predicate with a substituted-in value for the latest timestamp