### PR TITLE
Fix privacy manifest not declaring UserDefaults usage

### DIFF
--- a/Sources/OSLogClient/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/OSLogClient/Resources/PrivacyInfo.xcprivacy
@@ -10,7 +10,14 @@
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
[Apple Docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401)