### PR TITLE
Fix Minor Typo in LogClient Method Documentation

### DIFF
--- a/Sources/OSLogClient/Internal/LogClient.swift
+++ b/Sources/OSLogClient/Internal/LogClient.swift
@@ -72,7 +72,7 @@ class LogClient {
         await logPoller.registerDriver(driver)
     }
 
-    /// Will deregister the driver with the given identifier from receiving an logs.
+    /// Will deregister the driver with the given identifier from receiving any logs.
     /// - Parameter id: The id of the driver to deregister.
     func deregisterDriver(withId id: String) async {
         await logPoller.deregisterDriver(withId: id)


### PR DESCRIPTION
This PR adds a fix for a minor typo in the documentation for `LogClient.deregisterDriver(withId:)`.