### PR TITLE
Adding force/immediate polling convenience helper

### DIFF
--- a/Sources/OSLogClient/Internal/LogClient.swift
+++ b/Sources/OSLogClient/Internal/LogClient.swift
@@ -17,7 +17,8 @@ class LogClient {
     /// Internal logger for any console output.
     var logger: Logger = Logger(subsystem: "com.cheekyghost.OSLogClient", category: "client")
 
-    /// The current polling interval
+    /// The current polling interval. Defaults to ``PollingInterval/medium``
+    /// - See: ``PollingInterval``
     var pollingInterval: PollingInterval {
         didSet {
             pendingPollTask?.cancel()
@@ -37,9 +38,14 @@ class LogClient {
     /// Bool whether polling is currently active or not.
     var isPollingEnabled: Bool = false
 
+    /// Mapping of unique id's to a transient tasks created when the `forcePoll` is called.
+    /// These are managed for unit testing and potential future contexts (invalidation, cancelling etc)
+    /// A task is removed once it has completed.
+    var immediatePollTaskMap: [UUID: Task<(), Error>] = [:]
+
     // MARK: - Lifecycle
 
-    init(pollingInterval: PollingInterval, logStore: OSLogStore? = nil) throws {
+    required init(pollingInterval: PollingInterval = .medium, logStore: OSLogStore? = nil) throws {
         let store = try (logStore ?? OSLogStore(scope: .currentProcessIdentifier))
         self.logPoller = LogPoller(logStore: store, logger: logger)
         self.pollingInterval = pollingInterval
@@ -47,6 +53,7 @@ class LogClient {
 
     deinit {
         pendingPollTask?.cancel()
+        immediatePollTaskMap.forEach { $0.value.cancel() }
     }
 
     // MARK: - Helpers: Internal
@@ -70,6 +77,10 @@ class LogClient {
     /// - Parameter driver: The driver to register
     func registerDriver(_ driver: LogDriver) async {
         await logPoller.registerDriver(driver)
+        // If polling is enabled, but no pending task due to previously empty drivers, can start the polling up again
+        if isPollingEnabled, pendingPollTask == nil {
+            executePoll()
+        }
     }
 
     /// Will deregister the driver with the given identifier from receiving any logs.
@@ -80,6 +91,20 @@ class LogClient {
             pendingPollTask?.cancel()
             pendingPollTask = nil
         }
+    }
+
+    /// Will force an immediate poll of logs on a detached task.
+    /// **Note:** This does not reset or otherwise alter the current interval driven polling.
+    /// - Parameter date: Optional date to query from. Leave `nil` to query from the last time logs were polled (default behaviour).
+    func forcePoll(from date: Date? = nil) {
+        // Generate task
+        let taskId: UUID = .init()
+        let pollTask: Task<(), Error> = Task.detached(priority: .userInitiated) { [weak self, taskId] in
+            guard let self else { return }
+            await self.logPoller.pollLatestLogs(from: date)
+            self.immediatePollTaskMap.removeValue(forKey: taskId)
+        }
+        immediatePollTaskMap[taskId] = pollTask
     }
 
     /// Will execute the poll operation on the log poller instance.

--- a/Sources/OSLogClient/Internal/LogPoller.swift
+++ b/Sources/OSLogClient/Internal/LogPoller.swift
@@ -81,15 +81,17 @@ actor LogPoller {
     }
 
     /// Will poll logs since the last processed time position and send to any registered drivers for validation and processing.
-    func pollLatestLogs() {
+    /// - Parameter date: Optional date to request logs from. Leave this `nil` to default to the `lastProcessed` property.
+    func pollLatestLogs(from date: Date? = nil) {
         do {
             var predicate: NSPredicate?
-            if let lastProcessed {
+            let fromDate = date ?? lastProcessed
+            if let fromDate {
                 if datePredicate == nil {
                     datePredicate = NSPredicate(format: "date > $DATE")
                 }
                 
-                predicate = datePredicate?.withSubstitutionVariables(["DATE": lastProcessed])
+                predicate = datePredicate?.withSubstitutionVariables(["DATE": fromDate])
             }
             let items = try logStore.getEntries(matching: predicate).compactMap(validateLogEntry)
             let sortedItems = items.sorted(by: { $0.date <= $1.date })

--- a/Sources/OSLogClient/Public/LogDriver.swift
+++ b/Sources/OSLogClient/Public/LogDriver.swift
@@ -172,7 +172,7 @@ open class LogDriver: Equatable, CustomStringConvertible, CustomDebugStringConve
     // MARK: - CustomStringConvertible
 
     public var description: String {
-        "\(String(describing: self))<\(id)>"
+        "\(self)<\(id)>"
     }
 
     public var debugDescription: String {

--- a/Sources/OSLogClient/Public/LogDriver.swift
+++ b/Sources/OSLogClient/Public/LogDriver.swift
@@ -11,7 +11,7 @@ import OSLog
 /// `LogDriver` instances are responsible for handling processed os logs.
 /// Instances, when registered with the ``OSLogClient`` instance, will be sent logs from the `OSLogStore`.
 /// If  ``LogDriver/LogSource`` enums are provided, any incoming logs will be assessed against the log source rules and ignored if no matches are found.
-open class LogDriver: Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+open class LogDriver: Equatable {
 
     // MARK: - Supplementary
 
@@ -167,15 +167,5 @@ open class LogDriver: Equatable, CustomStringConvertible, CustomDebugStringConve
 
     public static func == (lhs: LogDriver, rhs: LogDriver) -> Bool {
         lhs.id == rhs.id
-    }
-
-    // MARK: - CustomStringConvertible
-
-    public var description: String {
-        "\(self)<\(id)>"
-    }
-
-    public var debugDescription: String {
-        description
     }
 }

--- a/Sources/OSLogClient/Public/OSLogClient.swift
+++ b/Sources/OSLogClient/Public/OSLogClient.swift
@@ -10,22 +10,22 @@ import Foundation
 
 /// Class that provides configurable polling of an `OSLogStore`.
 /// Valid log items will be sent to any registered ``LogDriver`` instances.
-///
+/// 
 /// Example usage:
 /// ```swift
 /// try OSLogClient.initialize(pollingInterval: .short)
 /// OSLogClient.registerDriver(driverSubclass)
 /// OSLogClient.startPolling()
 /// ```
-///
+/// 
 /// - You must initialize the utility using the ``OSLogClient/initialize(pollingInterval:logStore:)`` method **before use**. Failure
 /// to do this will result in a fatal error being thrown.
-///
+/// 
 /// - You can register ``LogDriver`` instances via the ``OSLogClient/registerDriver(_:)`` method.
-///
+/// 
 /// - By default polling will not automatically start, once you have finished setting up and registering drivers, you can start and stop
 /// polling by using the ``OSLogClient/startPolling()`` and ``OSLogClient/stopPolling()`` methods.
-///
+/// 
 public final class OSLogClient {
 
     // MARK: - Internal
@@ -86,6 +86,15 @@ public final class OSLogClient {
     /// Will stop polling logs.
     public static func stopPolling() {
         client.stopPolling()
+    }
+    
+    /// Will force an immediate poll of logs on a detached task. The same log processing and broadcasting to drivers will
+    /// occur as per the interval based polling.
+    ///
+    /// **Note:** This does not reset, delay, or otherwise alter the current polling interval (or scheduled tasks)
+    /// - Parameter date: Optional date to query from. Leave `nil` to query from the last time logs were polled (default behaviour).
+    public static func pollImmediately(from date: Date? = nil) {
+        client.forcePoll(from: date)
     }
 
     /// Will register the given driver instance to receive any polled logs.

--- a/Sources/OSLogClient/Public/PollingInterval.swift
+++ b/Sources/OSLogClient/Public/PollingInterval.swift
@@ -13,7 +13,7 @@ public enum PollingInterval: Equatable {
     case short
     /// Represents an interval of 30 seconds
     case medium
-    /// Represents an interval of 30 seconds
+    /// Represents an interval of 60 seconds
     case long
     /// Represents a custom polling interval (in seconds)
     ///

--- a/Tests/OSLogClientTests/LogClientTests.swift
+++ b/Tests/OSLogClientTests/LogClientTests.swift
@@ -140,4 +140,33 @@ final class LogClientTests: XCTestCase {
         instanceUnderTest.executePoll()
         XCTAssertNil(instanceUnderTest.pendingPollTask)
     }
+
+    func test_forcePoll_pollingEnabled_willAssignPollTask() throws {
+        instanceUnderTest.isPollingEnabled = true
+        instanceUnderTest.forcePollShouldForwardToSuper = true
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 0)
+        instanceUnderTest.forcePoll()
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 1)
+    }
+
+    func test_forcePoll_pollingDisabled_willAssignPollTask() throws {
+        instanceUnderTest.isPollingEnabled = false
+        instanceUnderTest.forcePollShouldForwardToSuper = true
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 0)
+        instanceUnderTest.forcePoll()
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 1)
+    }
+
+    func test_forcePoll_pollingTaskScheduled_willNotEffectPendingPollTask() throws {
+        instanceUnderTest.isPollingEnabled = true
+        instanceUnderTest.executePollShouldForwardToSuper = true
+        instanceUnderTest.forcePollShouldForwardToSuper = true
+        instanceUnderTest.startPolling()
+        let pendingTask = try XCTUnwrap(instanceUnderTest.pendingPollTask)
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 0)
+        instanceUnderTest.forcePoll()
+        XCTAssertEqual(instanceUnderTest.immediatePollTaskMap.count, 1)
+        XCTAssertNotNil(instanceUnderTest.pendingPollTask)
+        XCTAssertEqual(instanceUnderTest.pendingPollTask, pendingTask)
+    }
 }

--- a/Tests/OSLogClientTests/Mocks/LogClientPartialSpy.swift
+++ b/Tests/OSLogClientTests/Mocks/LogClientPartialSpy.swift
@@ -21,6 +21,20 @@ class LogClientPartialSpy: LogClient {
         }
     }
 
+    var forcePollCalled: Bool { forcePollCallCount > 0 }
+    var forcePollCallCount: Int = 0
+    var forcePollParameters: (date: Date?, Void)? { forcePollParameterList.last }
+    var forcePollParameterList: [(date: Date?, Void)] = []
+    var forcePollShouldForwardToSuper: Bool = false
+
+    override func forcePoll(from date: Date? = nil) {
+        forcePollCallCount += 1
+        forcePollParameterList.append((date: date, ()))
+        if forcePollShouldForwardToSuper {
+            super.forcePoll(from: date)
+        }
+    }
+
     var registerDriverCalled: Bool { registerDriverCallCount > 0 }
     var registerDriverCallCount: Int = 0
     var registerDriverParameters: (driver: LogDriver, Void)? { registerDriverParameterList.last }


### PR DESCRIPTION
- Added means to request an immediate polling of logs from a given point in time.
- Defaults to the last processed time. Once processed the lastProcessed is updated to the most processed log timestamp.
- Does not delay, reset, or otherwise alter the scheduled polling task.