### PR TITLE
[Feature] Add Check for Whether Driver Is Registered

### DIFF
--- a/Sources/OSLogClient/Internal/LogClient.swift
+++ b/Sources/OSLogClient/Internal/LogClient.swift
@@ -71,10 +71,17 @@ class LogClient {
         pendingPollTask = nil
     }
 
+    /// Indicates whether a driver with a specified identifier is registered.
+    /// - Parameter id: The id of the driver.
+    /// - Returns: A `Bool` indicating whether the a driver with the specified identifier is registered.
+    func isDriverRegistered(withId id: String) async -> Bool {
+        await logPoller.isDriverRegistered(withId: id)
+    }
+
     /// Will register the given driver instance to receive any polled logs.
     ///
     /// **Note:** The client will hold a strong reference to the driver instance.
-    /// - Parameter driver: The driver to register
+    /// - Parameter driver: The driver to register.
     func registerDriver(_ driver: LogDriver) async {
         await logPoller.registerDriver(driver)
         // If polling is enabled, but no pending task due to previously empty drivers, can start the polling up again

--- a/Sources/OSLogClient/Internal/LogPoller.swift
+++ b/Sources/OSLogClient/Internal/LogPoller.swift
@@ -56,12 +56,19 @@ actor LogPoller {
         self.logger = logger
     }
 
+    /// Indicates whether a driver with a specified identifier is registered.
+    /// - Parameter id: The id of the driver.
+    /// - Returns: A `Bool` indicating whether the a driver with the specified identifier is registered.
+    func isDriverRegistered(withId id: String) -> Bool {
+        drivers.contains(where: { $0.id == id })
+    }
+
     /// Will register the given driver instance to receive any polled logs.
     ///
     /// - Parameter driver: The driver to register
     func registerDriver(_ driver: LogDriver) {
-        guard !drivers.contains(where: { $0.id ==  driver.id }) else {
-            logger.error("Driver instance with id `\(driver.id)` is already registered.")
+        guard !isDriverRegistered(withId: driver.id) else {
+            logger.error("Driver instance with id `\(driver.id)` is already registered; consider checking whether a driver is already registered by invoking `LogPoller.isDriverRegistered(withId:)` before invoking `LogPoller.registerDriver(_:)`.")
             return
         }
         drivers.append(driver)

--- a/Tests/OSLogClientTests/LogClientTests.swift
+++ b/Tests/OSLogClientTests/LogClientTests.swift
@@ -73,6 +73,18 @@ final class LogClientTests: XCTestCase {
         XCTAssertNil(instanceUnderTest.pendingPollTask)
     }
 
+    func test_isDriverRegistered_withRegisteredDriver_willReturnTrue() async {
+        let driverSpy = LogDriverSpy(id: "test")
+        await instanceUnderTest.registerDriver(driverSpy)
+        let isRegistered = await instanceUnderTest.isDriverRegistered(withId: "test")
+        XCTAssertTrue(isRegistered)
+    }
+
+    func test_isDriverRegistered_withUnregisteredDriver_willReturnFalse() async {
+        let isRegistered = await instanceUnderTest.isDriverRegistered(withId: "test")
+        XCTAssertFalse(isRegistered)
+    }
+
     func test_registerDriver_notPresent_willAddToDriversArray() async {
         let driverSpy = LogDriverSpy(id: "test")
         await instanceUnderTest.registerDriver(driverSpy)


### PR DESCRIPTION
### Changes
The changes in the pull request include the ability to check whether a `LogDriver` is registered by calling `LogClient.isDriverRegistered(withId:)`.

### Motivation
When registering a `LogDriver` from a widget extension, the driver may be registered multiple times, leading to the following log output:
```swift
logger.error("Driver instance with id `\(driver.id)` is already registered.)
```
Because of this, I added a simple method, `LogClient.isDriverRegistered(withId:)`, to check whether a driver with a specified identifier is already registered.