### PR TITLE
[Feature] Make LogDriver ID Public

### DIFF
--- a/Sources/OSLogClient/Public/LogDriver.swift
+++ b/Sources/OSLogClient/Public/LogDriver.swift
@@ -63,7 +63,7 @@ open class LogDriver: Equatable {
     // MARK: - Properties
 
     /// Unique identifier for the driver.
-    let id: String
+    public let id: String
     
     /// Array of log sources to restrict logs sent to the `processLog(...)` method.
     ///


### PR DESCRIPTION
### Changes
The changes in the pull request include a switch from an implied `internal` access to a `public` access for `LogDriver.id`.

### Motivation
In pull request #13, I added a method to check whether a `LogDriver` is already registered. Unfortunately, I failed to change `LogDriver.id`'s access modifier to `public`. Changing `LogDriver.id` to `public` allows the property to be accessed from external modules. This is useful when, for example, a wrapper around `OSLogClient` lives in a module which is separate from the module which contains the `LogDriver`.