### PR TITLE
[Feature] Add Driver Registration Check to `OSLogClient`

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/OSLogClient.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/OSLogClient.xcscheme
@@ -52,6 +52,11 @@
                BlueprintName = "OSLogClientTests"
                ReferencedContainer = "container:">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "OSLogClientTests/test_logs_multipleDrivers_willReceiveLogsOnNextPoll()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Sources/OSLogClient/Public/OSLogClient.swift
+++ b/Sources/OSLogClient/Public/OSLogClient.swift
@@ -122,4 +122,11 @@ public final class OSLogClient {
             await client.deregisterDriver(withId: id)
         }
     }
+
+    /// Indicates whether a driver with a specified identifier is registered.
+    /// - Parameter id: The id of the driver.
+    /// - Returns: A `Bool` indicating whether the a driver with the specified identifier is registered.
+    public static func isDriverRegistered(withId id: String) async -> Bool {
+        await client.isDriverRegistered(withId: id)
+    }
 }

--- a/Tests/OSLogClientTests/LogClientTests.swift
+++ b/Tests/OSLogClientTests/LogClientTests.swift
@@ -18,6 +18,7 @@ final class LogClientTests: XCTestCase {
 
     override func setUpWithError() throws {
         instanceUnderTest = try LogClientPartialSpy(pollingInterval: .custom(5))
+        instanceUnderTest.isDriverRegisteredShouldForwardToSuper = true
         instanceUnderTest.registerDriverShouldForwardToSuper = true
         instanceUnderTest.deregisterDriverShouldForwardToSuper = true
     }

--- a/Tests/OSLogClientTests/Mocks/LogClientPartialSpy.swift
+++ b/Tests/OSLogClientTests/Mocks/LogClientPartialSpy.swift
@@ -62,4 +62,20 @@ class LogClientPartialSpy: LogClient {
             await super.deregisterDriver(withId: id)
         }
     }
+
+    var isDriverRegisteredCalled: Bool { isDriverRegisteredCallCount > 0 }
+    var isDriverRegisteredCallCount: Int = 0
+    var isDriverRegisteredParameters: (id: String, Void)? { isDriverRegisteredParameterList.last }
+    var isDriverRegisteredParameterList: [(id: String, Void)] = []
+    var isDriverRegisteredResult: Bool = false
+    var isDriverRegisteredShouldForwardToSuper: Bool = false
+
+    override func isDriverRegistered(withId id: String) async -> Bool {
+        isDriverRegisteredCallCount += 1
+        isDriverRegisteredParameterList.append((id, ()))
+        if isDriverRegisteredShouldForwardToSuper {
+            return await super.isDriverRegistered(withId: id)
+        }
+        return isDriverRegisteredResult
+    }
 }

--- a/Tests/OSLogClientTests/OSLogClientTests.swift
+++ b/Tests/OSLogClientTests/OSLogClientTests.swift
@@ -73,6 +73,25 @@ final class OSLogClientTests: XCTestCase {
         XCTAssertFalse(OSLogClient.isPolling)
     }
 
+    func test_isDriverRegisteredWithId_willReturnFalse_whenDriverIsNotRegistered() async throws {
+        let clientSpy = try LogClientPartialSpy(pollingInterval: .custom(1))
+        OSLogClient._client = clientSpy
+        try await wait(for: 0.1)
+        let isRegistered = await clientSpy.isDriverRegistered(withId: logDriverSpy.id)
+        XCTAssertFalse(isRegistered)
+    }
+
+    func test_isDriverRegisteredWithId_willReturnTrue_whenDriverIsRegistered() async throws {
+        let clientSpy = try LogClientPartialSpy(pollingInterval: .custom(1))
+        clientSpy.registerDriverShouldForwardToSuper = true
+        clientSpy.isDriverRegisteredShouldForwardToSuper = true
+        OSLogClient._client = clientSpy
+        OSLogClient.registerDriver(logDriverSpy)
+        try await wait(for: 0.1)
+        let isRegistered = await clientSpy.isDriverRegistered(withId: logDriverSpy.id)
+        XCTAssertTrue(isRegistered)
+    }
+
     func test_registerDriver_willInvokeClient() async throws {
         let clientSpy = try LogClientPartialSpy(pollingInterval: .custom(1))
         OSLogClient._client = clientSpy


### PR DESCRIPTION
### Changes
The changes in the pull request include the addition of `static OSLogClient.isDriverRegistered(withId:)` and related tests.

### Motivation
In pull requests #13 & #14, I failed to add `isDriverRegistered(withId:)` to `OSLogClient`, so the method was not accessible from external modules. The method is now a `public` member of `OSLogClient`.