### PR TITLE
Introduce more flexible LogFilter to replace LogSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ class TextLogDriver: LogDriver {
 	
     // MARK: - Lifecycle
 	
-    required init(id: String, logFileUrl: URL, logSources: [LogSource] = []) {
+    required init(id: String, logFileUrl: URL, logFilters: [LogFilter] = []) {
         self.logFileUrl = logFileUrl
-        super.init(id: id, logSources: logSources)
+        super.init(id: id, logFilters: logFilters)
     }
     
-    required init(id: String, logSources: [LogDriver.LogSource] = []) {
-        fatalError("init(id:logSources:) has not been implemented")
+    required init(id: String, logFilters: [LogFilter] = []) {
+        fatalError("init(id:logFilters:) has not been implemented")
     }
 	
     // MARK: - Overrides
@@ -130,29 +130,23 @@ class TextLogDriver: LogDriver {
 }
 ```
 
-## Filtering Logs with LogSource Filters
+## Filtering Logs with LogFilter
 
-Instead of only assessing log level, date, and category in the `processLog` method, you can fine-tune which logs should be processed by a `LogDriver` instance by specifying valid `LogSource` enum cases.
+Instead of only assessing log level, date, and category in the `processLog` method, you can fine-tune which logs should be processed by a `LogDriver` instance by specifying valid `LogFilter` conditions.
 
 If log filters are specified (i.e., the list isn't empty), they're used to evaluate incoming log entries, ensuring there's a matching filter.
 
-Currently, two source options are supported:
+See the `LogFilter` and `LogCategoryFilter` documentation for supported options.
 
-- `.subsystem(String)`: Includes logs where the `subsystem` matches the provided string.
-- `.subsystemAndCategories(subsystem: String, categories: [String])`: Includes logs where the `subsystem` matches the provided string **and** the log `category` is in the `categories` array.
-
-For instance, to configure a log driver to only receive `ui` and `api` log entries:
+For example, to configure a log driver to only receive `ui` and `api` log entries:
 
 ```swift
 let apiLogger = Logger(subsystem: "com.company.AppName", category: "api")
 let uiLogger = Logger(subsystem: "com.company.AppName", category: "ui")
 let storageLogger = Logger(subsystem: "com.vendor.AppName", category: "storage")
 
-myLogDriver.addLogSources([
-  .subsystemAndCategories(
-    subsystem: "com.company.AppName",
-    categories: ["ui", "api"]
-  )
+myLogDriver.addLogFilters([
+  .subsystem("com.company.AppName", categories: "ui", "api")
 ])
 ```
 

--- a/Sources/OSLogClient/Internal/Convenience/Array+LogCategoryFilterIdentifier.swift
+++ b/Sources/OSLogClient/Internal/Convenience/Array+LogCategoryFilterIdentifier.swift
@@ -1,0 +1,17 @@
+//
+//  Array+LogCategoryFilterIdentifier.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+extension [LogCategoryFilter] {
+    /// Concatenates all the ``LogCategory/identifier``s or `<no-filters>` if the array is empty.
+    var identifier: String {
+        if isEmpty {
+            return "<no-filters>"
+        } else {
+            return map(\.identifier).joined(separator: ",")
+        }
+    }
+}

--- a/Sources/OSLogClient/Public/LogFilters/LogCategoryFilter.swift
+++ b/Sources/OSLogClient/Public/LogFilters/LogCategoryFilter.swift
@@ -1,0 +1,98 @@
+//
+//  LogCategoryFilter.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+/// A definition of a condition which the ``LogDriver`` uses to restrict logs that will be processed.
+public struct LogCategoryFilter: Hashable, ExpressibleByStringLiteral {
+    typealias EvaluatorFunction = (_ category: String) -> Bool
+
+    /// An identifier for this filter and its condition.
+    let identifier: String
+
+    /// The function that performs evaluation.
+    private let evaluator: EvaluatorFunction
+
+    init(identifier: String, evaluator: @escaping EvaluatorFunction) {
+        self.identifier = identifier
+        self.evaluator = evaluator
+    }
+
+    /// Creates a ``LogCategoryFilter`` which compares only the `OSLogEntryLog` category with the supplied category.
+    ///
+    /// - Note: The supplied category is compared case-insensitive.
+    /// - Parameter value: The category to compare against.
+    /// - Returns: The ``LogCategoryFilter`` to provide to a ``LogFilter``.
+    public init(stringLiteral value: StringLiteralType) {
+        let value = value.lowercased()
+        self.init(identifier: "category:matches(\(value))") { category in
+            return value == category
+        }
+    }
+
+    /// Performs checks against the provided subsystem and category against the evaluator function supplied during initialization.
+    ///
+    /// - Parameter category: The category of the `OSLogEntryLog` object. The value will be lowercased before being evaluated.
+    /// - Returns: `Bool` result from the evaluator function.
+    func evaluate(againstCategory category: String) -> Bool {
+        evaluator(category.lowercased())
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+    }
+
+    public static func == (lhs: LogCategoryFilter, rhs: LogCategoryFilter) -> Bool {
+        lhs.identifier == rhs.identifier
+    }
+
+    // MARK: Conditions
+
+    /// - SeeAlso: ``init(stringLiteral:)``
+    public static func matches(_ value: String) -> LogCategoryFilter {
+        return LogCategoryFilter(stringLiteral: value)
+    }
+
+    /// Creates a ``LogCategoryFilter`` which evaluates if the `OSLogEntryLog` category begins with the specified prefix.
+    ///
+    /// - Note: The supplied prefix is compared case-insensitive.
+    /// - Parameter prefix: The prefix to compare against.
+    /// - Returns: The ``LogCategoryFilter`` to provide to a ``LogFilter``.
+    public static func startsWith(_ prefix: String) -> LogCategoryFilter {
+        let prefix = prefix.lowercased()
+        return LogCategoryFilter(identifier: "category:startsWith(\(prefix))") { category in
+            category.hasPrefix(prefix)
+        }
+    }
+
+    /// Creates a ``LogCategoryFilter`` which evaluates if the `OSLogEntryLog` category contains the specified value.
+    ///
+    /// - Note: The supplied value is compared case-insensitive.
+    /// - Parameter value: The category to compare against.
+    /// - Returns: The ``LogCategoryFilter`` to provide to a ``LogFilter``.
+    public static func contains(_ value: String) -> LogCategoryFilter {
+        let value = value.lowercased()
+        return LogCategoryFilter(identifier: "category:contains(\(value))") { category in
+            category.contains(value)
+        }
+    }
+
+    /// Creates a ``LogCategoryFilter`` which evaluates to the inverse of the supplied ``LogCategoryFilter``.
+    ///
+    /// The output of this filter will be as follows:
+    /// | Supplied Filter's Output | This Filter Output |
+    /// | --- | --- |
+    /// | `true` | `false` |
+    /// | `false` | `true` |
+    ///
+    /// - Parameter filter: The filter to invert.
+    /// - Returns: The ``LogCategoryFilter`` to provide to a ``LogFilter``.
+    public static func not(_ filter: LogCategoryFilter) -> LogCategoryFilter {
+        return LogCategoryFilter(identifier: "not(\(filter.identifier))") { category in
+            let result = filter.evaluate(againstCategory: category)
+            return !result
+        }
+    }
+}

--- a/Sources/OSLogClient/Public/LogFilters/LogFilter.swift
+++ b/Sources/OSLogClient/Public/LogFilters/LogFilter.swift
@@ -1,0 +1,187 @@
+//
+//  LogFilter.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+/// A definition of a condition which the ``LogDriver`` uses to restrict logs that will be processed.
+public struct LogFilter: Hashable {
+    typealias EvaluatorFunction = (_ subsystem: String, _ category: String) -> Bool
+
+    /// An identifier for this filter and its condition.
+    let identifier: String
+
+    /// The function that performs evaluation.
+    private let evaluator: EvaluatorFunction
+
+    init(identifier: String, evaluator: @escaping EvaluatorFunction) {
+        self.identifier = identifier
+        self.evaluator = evaluator
+    }
+
+    /// Performs checks against the provided subsystem and category against the evaluator function supplied during initialization.
+    ///
+    /// - Parameters:
+    ///   - subsystem: The subsystem of the `OSLogEntryLog` object. The value will be lowercased before being evaluated.
+    ///   - category: The category of the `OSLogEntryLog` object. The value will be lowercased before being evaluated.
+    /// - Returns: `Bool` result from the evaluator function.
+    func evaluate(againstSubsystem subsystem: String, category: String) -> Bool {
+        evaluator(subsystem.lowercased(), category.lowercased())
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+    }
+
+    public static func == (lhs: LogFilter, rhs: LogFilter) -> Bool {
+        lhs.identifier == rhs.identifier
+    }
+
+    // MARK: Exact match
+
+    /// Creates a ``LogFilter`` which compares only the `OSLogEntryLog` subsystem with the supplied subsystem.
+    ///
+    /// - Note: The supplied subsystem is compared case-insensitive.
+    /// - Parameter value: The subsystem to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    public static func subsystem(_ value: String) -> LogFilter {
+        let value = value.lowercased()
+        return LogFilter(identifier: "subsystem:matches(\(value))") { subsystem, _ in
+            return value == subsystem
+        }
+    }
+
+    /// Creates a ``LogFilter`` which compares the `OSLogEntryLog` subsystem and category with the supplied subsystem and category filters.
+    ///
+    /// - Note: The supplied subsystem is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - value: The subsystem to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    public static func subsystem(_ value: String, categories: [LogCategoryFilter]) -> LogFilter {
+        let value = value.lowercased()
+        let subsystemFilter = LogFilter.subsystem(value)
+        return combine(subsystemFilter: subsystemFilter, categoryFilters: categories)
+    }
+
+    /// Creates a ``LogFilter`` which compares the `OSLogEntryLog` subsystem and category with the supplied subsystem and category filters.
+    ///
+    /// - Note: The supplied subsystem is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - value: The subsystem to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    @inlinable public static func subsystem(_ value: String, categories: LogCategoryFilter...) -> LogFilter {
+        return subsystem(value, categories: categories)
+    }
+
+    // MARK: Starts With
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem begins with the specified prefix.
+    ///
+    /// - Note: The supplied prefix is compared case-insensitive.
+    /// - Parameter prefix: The prefix to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    public static func subsystem(startsWith prefix: String) -> LogFilter {
+        let prefix = prefix.lowercased()
+        return LogFilter(identifier: "subsystem:startsWith(\(prefix))") { subsystem, _ in
+            subsystem.hasPrefix(prefix)
+        }
+    }
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem begins with the specified prefix and if the `OSLogEntryLog` category matches the category filters.
+    ///
+    /// - Note: The supplied prefix is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - prefix: The prefix to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    public static func subsystem(startsWith prefix: String, categories: [LogCategoryFilter]) -> LogFilter {
+        let prefix = prefix.lowercased()
+        let subsystemFilter = LogFilter.subsystem(startsWith: prefix)
+        return combine(subsystemFilter: subsystemFilter, categoryFilters: categories)
+    }
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem begins with the specified prefix and if the `OSLogEntryLog` category matches the category filters.
+    ///
+    /// - Note: The supplied prefix is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - prefix: The prefix to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    @inlinable public static func subsystem(startsWith prefix: String, categories: LogCategoryFilter...) -> LogFilter {
+        return subsystem(startsWith: prefix, categories: categories)
+    }
+
+    // MARK: Contains
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem contains the specified value.
+    ///
+    /// - Note: The supplied value is compared case-insensitive.
+    /// - Parameter value: The subsystem to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    public static func subsystem(contains value: String) -> LogFilter {
+        let value = value.lowercased()
+        return LogFilter(identifier: "subsystem:contains(\(value))") { subsystem, _ in
+            subsystem.contains(value)
+        }
+    }
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem contains the specified value and if the `OSLogEntryLog` category matches the category filters.
+    ///
+    /// - Note: The supplied value is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - value: The subsystem to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    public static func subsystem(contains value: String, categories: [LogCategoryFilter]) -> LogFilter {
+        let value = value.lowercased()
+        let subsystemFilter = LogFilter.subsystem(contains: value)
+        return combine(subsystemFilter: subsystemFilter, categoryFilters: categories)
+    }
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` subsystem contains the specified value and if the `OSLogEntryLog` category matches the category filters.
+    ///
+    /// - Note: The supplied value is compared case-insensitive. Categories are evaluated in order and until a filter evaluates `true`. See ``LogCategoryFilter``.
+    /// - Parameters:
+    ///   - value: The subsystem to compare against.
+    ///   - categories: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    /// - SeeAlso: ``LogCategoryFilter``
+    @inlinable public static func subsystem(contains value: String, categories: LogCategoryFilter...) -> LogFilter {
+        return subsystem(contains: value, categories: categories)
+    }
+
+    // MARK: Syntax-sugar
+
+    /// Creates a ``LogFilter`` which evaluates if the `OSLogEntryLog` category matches the filters, it does not compare the subsystem.
+    ///
+    /// - Note: The supplied value is compared case-insensitive.
+    /// - Parameter categoryFilter: The category filters to compare against.
+    /// - Returns: The ``LogFilter`` to provide to a ``LogDriver``.
+    public static func category(_ categoryFilter: LogCategoryFilter) -> LogFilter {
+        return LogFilter(identifier: categoryFilter.identifier) { _, category in
+            categoryFilter.evaluate(againstCategory: category)
+        }
+    }
+
+    // MARK: - Convenience
+
+    /// Convenience to combine a subsystem filter with an array of category filters.
+    ///
+    /// - NOTE: This function will ensure the subsystem and category are evaluated in a performant manner by not evaluating the categories
+    ///         if the subsystem evaluation fails. When evaluating the categories it will also stop evaluation early if any filter returns `true`.
+    private static func combine(subsystemFilter: LogFilter, categoryFilters: [LogCategoryFilter]) -> LogFilter {
+        return LogFilter(identifier: "\(subsystemFilter.identifier)&[\(categoryFilters.identifier)]") { subsystem, category in
+            // Evaluated as part of the same expression to utilise short-circuit logic
+            return subsystemFilter.evaluate(againstSubsystem: subsystem, category: category) &&
+                categoryFilters.contains(where: { $0.evaluate(againstCategory: category) })
+        }
+    }
+}

--- a/Tests/OSLogClientTests/Internal/ArrayLogCategoryFilterIdentifierTests.swift
+++ b/Tests/OSLogClientTests/Internal/ArrayLogCategoryFilterIdentifierTests.swift
@@ -1,0 +1,31 @@
+//
+//  ArrayLogCategoryFilterIdentifierTests.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+@testable import OSLogClient
+import XCTest
+
+final class ArrayLogCategoryFilterIdentifierTests: XCTestCase {
+    func test_identifier_withNoItems_outputsExpectedValue() {
+        let filters: [LogCategoryFilter] = []
+        XCTAssertEqual(filters.identifier, "<no-filters>")
+    }
+
+    func test_identifier_withSingleItem_outputsExpectedValue() {
+        let filters: [LogCategoryFilter] = [
+            .matches("cat-ui"),
+        ]
+        XCTAssertEqual(filters.identifier, "category:matches(cat-ui)")
+    }
+
+    func test_identifier_moreThanOneItem_outputsExpectedValue() {
+        let filters: [LogCategoryFilter] = [
+            .matches("cat-ui"),
+            .matches("cat-api"),
+        ]
+        XCTAssertEqual(filters.identifier, "category:matches(cat-ui),category:matches(cat-api)")
+    }
+}

--- a/Tests/OSLogClientTests/Public/LogDriverTests.swift
+++ b/Tests/OSLogClientTests/Public/LogDriverTests.swift
@@ -1,15 +1,14 @@
 //
 //  LogDriverTests.swift
-//  
+//
 //
 //  Copyright © 2023 CheekyGhost Labs. All rights reserved.
 //
 
-import XCTest
 @testable import OSLogClient
+import XCTest
 
 final class LogDriverTests: XCTestCase {
-
     // MARK: - Properties
 
     var instanceUnderTest: LogDriver!
@@ -27,9 +26,9 @@ final class LogDriverTests: XCTestCase {
     }
 
     func test_isLogValid_subsystemFilter_willReturnExpectedResults() {
-        instanceUnderTest.addLogSources([
+        instanceUnderTest.addLogFilters([
             .subsystem("system-one"),
-            .subsystem("system-two")
+            .subsystem("system-two"),
         ])
         XCTAssertTrue(instanceUnderTest.isValidLogSource(subsystem: "system-one", category: "any"))
         XCTAssertTrue(instanceUnderTest.isValidLogSource(subsystem: "system-two", category: "any"))
@@ -37,10 +36,11 @@ final class LogDriverTests: XCTestCase {
     }
 
     func test_isLogValid_subsystemAndCategoriesFilter_willReturnExpectedResults() {
-        instanceUnderTest.addLogSources([
-            .subsystemAndCategories(subsystem: "system-one", categories: ["cat-ui"]),
-            .subsystemAndCategories(subsystem: "system-two", categories: ["cat-api", "cat-errors"]),
-            .subsystemAndCategories(subsystem: "system-three", categories: ["cat-ui", "cat-api", "cat-errors"]),
+        instanceUnderTest.addLogFilters([
+            .subsystem("system-one", categories: "cat-ui"),
+            .subsystem("system-one", categories: "cat-ui"),
+            .subsystem("system-two", categories: "cat-api", "cat-errors"),
+            .subsystem("system-three", categories: "cat-ui", "cat-api", "cat-errors"),
         ])
         XCTAssertTrue(instanceUnderTest.isValidLogSource(subsystem: "system-one", category: "cat-ui"))
         XCTAssertFalse(instanceUnderTest.isValidLogSource(subsystem: "system-one", category: "cat-api"))
@@ -57,9 +57,9 @@ final class LogDriverTests: XCTestCase {
     }
 
     func test_isLogValid_mixedFilters_willReturnExpectedResults() {
-        instanceUnderTest.addLogSources([
+        instanceUnderTest.addLogFilters([
             .subsystem("system-one"),
-            .subsystemAndCategories(subsystem: "system-two", categories: ["cat-ui", "cat-api"]),
+            .subsystem("system-two", categories: ["cat-ui", "cat-api"]),
         ])
         XCTAssertTrue(instanceUnderTest.isValidLogSource(subsystem: "system-one", category: "cat-ui"))
         XCTAssertTrue(instanceUnderTest.isValidLogSource(subsystem: "system-one", category: "cat-api"))

--- a/Tests/OSLogClientTests/Public/LogFilters/LogCategoryFilterTests.swift
+++ b/Tests/OSLogClientTests/Public/LogFilters/LogCategoryFilterTests.swift
@@ -1,0 +1,77 @@
+//
+//  LogCategoryFilterTests.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+@testable import OSLogClient
+import XCTest
+
+final class LogCategoryFilterTests: XCTestCase {
+    func test_identifier_calculatedAsExpected() {
+        // String literal ends up as matches
+        let stringLiteral: LogCategoryFilter = "cat-ui"
+        XCTAssertEqual(stringLiteral.identifier, "category:matches(cat-ui)")
+
+        // Standard convenience creation
+        let matches = LogCategoryFilter.matches("cat-ui")
+        XCTAssertEqual(matches.identifier, "category:matches(cat-ui)")
+        let contains = LogCategoryFilter.contains("cat-ui")
+        XCTAssertEqual(contains.identifier, "category:contains(cat-ui)")
+        let startsWith = LogCategoryFilter.startsWith("cat-ui")
+        XCTAssertEqual(startsWith.identifier, "category:startsWith(cat-ui)")
+
+        // Logic inversion
+        let not = LogCategoryFilter.not(.matches("cat-ui"))
+        XCTAssertEqual(not.identifier, "not(category:matches(cat-ui))")
+    }
+
+    func test_setRemovesDuplicates() {
+        let filters: Set<LogCategoryFilter> = [
+            LogCategoryFilter.matches("cat-ui"),
+            LogCategoryFilter.matches("cat-api"),
+            LogCategoryFilter.matches("cat-UI"),
+            LogCategoryFilter.startsWith("cat-ui"),
+        ]
+        XCTAssertEqual(filters.count, 3)
+    }
+
+    func test_matchesFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogCategoryFilter.matches("cat-ui")
+        XCTAssertEqual(subsystemMatches.identifier, "category:matches(cat-ui)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-UI"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstCategory: "cat-api"))
+    }
+
+    func test_containsFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogCategoryFilter.contains("ui")
+        XCTAssertEqual(subsystemMatches.identifier, "category:contains(ui)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-UI"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstCategory: "cat-api"))
+    }
+
+    func test_startsWithFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogCategoryFilter.startsWith("cat-")
+        XCTAssertEqual(subsystemMatches.identifier, "category:startsWith(cat-)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstCategory: "cat-UI"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstCategory: "app-ui"))
+    }
+
+    func test_notFilter_willReturnExpectedResults() {
+        let categoryFilter = LogCategoryFilter.matches("cat-ui")
+        XCTAssertEqual(categoryFilter.identifier, "category:matches(cat-ui)")
+        XCTAssertTrue(categoryFilter.evaluate(againstCategory: "cat-ui"))
+        XCTAssertTrue(categoryFilter.evaluate(againstCategory: "cat-UI"))
+        XCTAssertFalse(categoryFilter.evaluate(againstCategory: "app-ui"))
+
+        let invertedFilter = LogCategoryFilter.not(categoryFilter)
+        XCTAssertEqual(invertedFilter.identifier, "not(category:matches(cat-ui))")
+        XCTAssertFalse(invertedFilter.evaluate(againstCategory: "cat-ui"))
+        XCTAssertFalse(invertedFilter.evaluate(againstCategory: "cat-UI"))
+        XCTAssertTrue(invertedFilter.evaluate(againstCategory: "app-ui"))
+    }
+}

--- a/Tests/OSLogClientTests/Public/LogFilters/LogFilterTests.swift
+++ b/Tests/OSLogClientTests/Public/LogFilters/LogFilterTests.swift
@@ -1,0 +1,117 @@
+//
+//  LogFilterTests.swift
+//
+//
+//  Created by Joshua Asbury on 2/6/2024.
+//
+
+@testable import OSLogClient
+import XCTest
+
+final class LogFilterTests: XCTestCase {
+    func test_identifier_calculatedAsExpected() {
+        // No categories
+        let matches = LogFilter.subsystem("system-one")
+        XCTAssertEqual(matches.identifier, "subsystem:matches(system-one)")
+        let contains = LogFilter.subsystem(contains: "system-one")
+        XCTAssertEqual(contains.identifier, "subsystem:contains(system-one)")
+        let startsWith = LogFilter.subsystem(startsWith: "system-one")
+        XCTAssertEqual(startsWith.identifier, "subsystem:startsWith(system-one)")
+
+        // With Categories
+        let matchesCategory = LogFilter.subsystem("system-one", categories: "cat-ui")
+        XCTAssertEqual(matchesCategory.identifier, "subsystem:matches(system-one)&[category:matches(cat-ui)]")
+        let containsCategory = LogFilter.subsystem(contains: "system-one", categories: "cat-ui")
+        XCTAssertEqual(containsCategory.identifier, "subsystem:contains(system-one)&[category:matches(cat-ui)]")
+        let startsWithCategory = LogFilter.subsystem(startsWith: "system-one", categories: "cat-ui")
+        XCTAssertEqual(startsWithCategory.identifier, "subsystem:startsWith(system-one)&[category:matches(cat-ui)]")
+        let matchesRespectsCategory = LogFilter.subsystem("system-one", categories: .startsWith("cat-ui"))
+        XCTAssertEqual(matchesRespectsCategory.identifier, "subsystem:matches(system-one)&[category:startsWith(cat-ui)]")
+    }
+
+    func test_setRemovesDuplicates() {
+        let filters: Set<LogFilter> = [
+            LogFilter.subsystem("system-one"),
+            LogFilter.subsystem("system-one"),
+            LogFilter.subsystem("system-one", categories: "app-ui"), // constrains by category, not a dupe
+            LogFilter.subsystem("system-one", categories: "app-ui"),
+            LogFilter.subsystem("system-1"),
+        ]
+        XCTAssertEqual(filters.count, 3)
+    }
+
+    func test_subsystemMatchesFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem("system-one")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:matches(system-one)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "irrelevant"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "irrelevant"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "irrelevant"))
+    }
+
+    func test_subsystemContainsFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem(contains: "one")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:contains(one)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "irrelevant"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "irrelevant"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "irrelevant"))
+    }
+
+    func test_subsystemStartsWithFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem(startsWith: "system-")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:startsWith(system-)")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "irrelevant"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "irrelevant"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "subsystem-1", category: "irrelevant"))
+    }
+
+    func test_subsystemMatchesWithCategoriesFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem("system-one", categories: "cat-ui")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:matches(system-one)&[category:matches(cat-ui)]")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "cat-ui"))
+
+        // Category does not match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-api"))
+        // Subsystem does not match, category does
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "cat-ui"))
+        // Neither subsystem nor category match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "cat-api"))
+    }
+
+    func test_subsystemContainsWithCategoriesFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem(contains: "one", categories: "cat-ui")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:contains(one)&[category:matches(cat-ui)]")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "cat-ui"))
+
+        // Category does not match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-api"))
+        // Subsystem does not match, category does
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "cat-ui"))
+        // Neither subsystem nor category match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-1", category: "cat-api"))
+    }
+
+    func test_subsystemStartsWithWithCategoriesFilter_willReturnExpectedResults() {
+        let subsystemMatches = LogFilter.subsystem(startsWith: "system-", categories: "cat-ui")
+        XCTAssertEqual(subsystemMatches.identifier, "subsystem:startsWith(system-)&[category:matches(cat-ui)]")
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "system-ONE", category: "cat-ui"))
+
+        // Category does not match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "system-one", category: "cat-api"))
+        // Subsystem does not match, category does
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "subsystem-1", category: "cat-ui"))
+        // Neither subsystem nor category match
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "subsystem-1", category: "cat-api"))
+    }
+
+    func test_categorySyntaxSugar_willReturnExpectedResults() {
+        let categoryFilter = LogCategoryFilter.matches("cat-ui")
+        let subsystemMatches = LogFilter.category(categoryFilter)
+        XCTAssertEqual(categoryFilter.identifier, subsystemMatches.identifier)
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "irrelevant", category: "cat-ui"))
+        XCTAssertTrue(subsystemMatches.evaluate(againstSubsystem: "irrelevant", category: "cat-UI"))
+        XCTAssertFalse(subsystemMatches.evaluate(againstSubsystem: "irrelevant", category: "cat-api"))
+    }
+}

--- a/Tests/OSLogClientTests/Public/OSLogClientIntegrationTests.swift
+++ b/Tests/OSLogClientTests/Public/OSLogClientIntegrationTests.swift
@@ -5,12 +5,11 @@
 //  Copyright © 2023 CheekyGhost Labs. All rights reserved.
 //
 
-import XCTest
 import OSLog
 @testable import OSLogClient
+import XCTest
 
 final class OSLogClientIntegrationTests: XCTestCase {
-
     let subsystem = "com.cheekyghost.OSLogClient.tests"
     let logCategory = "tests"
     var logClient: LogClient!
@@ -25,11 +24,11 @@ final class OSLogClientIntegrationTests: XCTestCase {
         logClient = LogClient(pollingInterval: .custom(1), lastProcessedStrategy: lastProcessedStrategy, logStore: logStore)
         logDriverSpy = LogDriverSpy(
             id: "unit-tests",
-            logSources: [.subsystem("com.cheekyghost.OSLogClient.tests")]
+            logFilters: [.subsystem("com.cheekyghost.OSLogClient.tests")]
         )
         logDriverSpyTwo = LogDriverSpy(
             id: "unit-tests-two",
-            logSources: [.subsystemAndCategories(subsystem: "com.cheekyghost.OSLogClient.tests", categories: ["tests"])]
+            logFilters: [.subsystem("com.cheekyghost.OSLogClient.tests", categories: "tests")]
         )
         OSLogClient._client = logClient
     }

--- a/Tests/OSLogClientTests/Utils/Mocks/LogDriverSpy.swift
+++ b/Tests/OSLogClientTests/Utils/Mocks/LogDriverSpy.swift
@@ -10,7 +10,6 @@ import OSLog
 @testable import OSLogClient
 
 class LogDriverSpy: LogDriver {
-
 #if os(macOS)
     typealias ProcessLogParameters = (
         level: LogDriver.LogLevel,
@@ -21,7 +20,7 @@ class LogDriverSpy: LogDriver {
         components: [OSLogMessageComponent]
     )
     var processLogCalled: Bool { processLogCallCount > 0 }
-    var processLogCallCount: Int = 0
+    var processLogCallCount: Int { processLogParameterList.count }
     var processLogParameters: ProcessLogParameters? { processLogParameterList.last }
     var processLogParameterList: [ProcessLogParameters] = []
 
@@ -33,24 +32,21 @@ class LogDriverSpy: LogDriver {
         message: String,
         components: [OSLogMessageComponent]
     ) {
-        processLogCallCount += 1
         processLogParameterList.append((level, subsystem, category, date, message, components))
     }
 #else
     typealias ProcessLogParameters = (level: LogDriver.LogLevel, subsystem: String, category: String, date: Date, message: String)
     var processLogCalled: Bool { processLogCallCount > 0 }
-    var processLogCallCount: Int = 0
+    var processLogCallCount: Int { processLogParameterList.count }
     var processLogParameters: ProcessLogParameters? { processLogParameterList.last }
     var processLogParameterList: [ProcessLogParameters] = []
 
     override func processLog(level: LogDriver.LogLevel, subsystem: String, category: String, date: Date, message: String) {
-        processLogCallCount += 1
         processLogParameterList.append((level, subsystem, category, date, message))
     }
 #endif
 
     func reset() {
-        processLogCallCount = 0
-        processLogParameterList = []
+        processLogParameterList.removeAll()
     }
 }


### PR DESCRIPTION
I found it extremely useful in my own usages to be able to define filters like this, specifically I had quite a number of subsystems that shared a prefix. Instead of needing to worry about adding a new source each time it worked well to be able to provide the prefix and have the log client pick up on new subsystems/categories as they were added.