### PR TITLE
Fix LastProcessedStrategy extensions were not marked public

### DIFF
--- a/Sources/OSLogClient/Public/LastProcessedStrategy/InMemoryLastProcessedStrategy.swift
+++ b/Sources/OSLogClient/Public/LastProcessedStrategy/InMemoryLastProcessedStrategy.swift
@@ -13,7 +13,7 @@ public class InMemoryLastProcessedStrategy: LastProcessedStrategy {
     }
 }
 
-extension LastProcessedStrategy where Self == InMemoryLastProcessedStrategy {
+public extension LastProcessedStrategy where Self == InMemoryLastProcessedStrategy {
     static var inMemory: Self {
         Self()
     }

--- a/Sources/OSLogClient/Public/LastProcessedStrategy/UserDefaultsLastProcessedStrategy.swift
+++ b/Sources/OSLogClient/Public/LastProcessedStrategy/UserDefaultsLastProcessedStrategy.swift
@@ -32,13 +32,13 @@ public struct UserDefaultsLastProcessedStrategy: LastProcessedStrategy {
     }
 }
 
-extension LastProcessedStrategy where Self == UserDefaultsLastProcessedStrategy {
+public extension LastProcessedStrategy where Self == UserDefaultsLastProcessedStrategy {
     static func userDefaults(key: String, defaults: UserDefaults = .standard) -> Self {
         Self(key: key, defaults: defaults)
     }
 
     /// Will return the library default strategy which resolves to ``LastProcessedStrategy/userDefaults(key:)``
-    public static var `default`: Self {
+    static var `default`: Self {
         .userDefaults(key: "com.cheekyghost.axologl.lastProcessed")
     }
 }


### PR DESCRIPTION
What use are inaccessible strategies 😆

The only one marked public for access was the default strategy.