### PR TITLE
Add frozen to LogLevel enum

### DIFF
--- a/Sources/OSLogClient/Public/LogDriver.swift
+++ b/Sources/OSLogClient/Public/LogDriver.swift
@@ -15,7 +15,7 @@ open class LogDriver: Equatable {
     // MARK: - Supplementary
 
     /// Enumeration of supported log levels.
-    public enum LogLevel: String, CaseIterable {
+    @frozen public enum LogLevel: String, CaseIterable {
         /// The log level was never specified.
         case undefined
         /// A log level that captures diagnostic information.


### PR DESCRIPTION
Added `@frozen` to `LogDriver.LogLevel` so that implementers of a driver don't need to add a `@unknown default` case to the switch.

I was considering adding it to `OSLogClientError` as well, but it's probably less likely that a consumer is switching over that enum.