### PR TITLE
Swift 6 language mode support

### DIFF
--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,9 +19,6 @@ let package = Package(
             name: "OSLogClient",
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v6)
             ]
         ),
         .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,9 +19,6 @@ let package = Package(
             name: "OSLogClient",
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v6)
             ]
         ),
         .testTarget(

--- a/Sources/OSLogClient/Internal/ProcessInfoProvider.swift
+++ b/Sources/OSLogClient/Internal/ProcessInfoProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Internal protocol used to facilitate unit-testing only support for some scenarios.
 /// This is due to not being able to use a traditional spy/mock setup for actors.
-protocol ProcessInfoEnvironmentProvider: AnyObject {
+protocol ProcessInfoEnvironmentProvider: AnyObject, Sendable {
 
     /// Dictionary of environment variables available from the current process.
     var processInfoEnvironment: [String : String] { get }

--- a/Sources/OSLogClient/Public/LastProcessedStrategy/InMemoryLastProcessedStrategy.swift
+++ b/Sources/OSLogClient/Public/LastProcessedStrategy/InMemoryLastProcessedStrategy.swift
@@ -5,11 +5,16 @@
 //  Created by Joshua Asbury on 24/8/2024.
 //
 
-public class InMemoryLastProcessedStrategy: LastProcessedStrategy {
+public final class InMemoryLastProcessedStrategy: LastProcessedStrategy, Equatable, @unchecked Sendable {
+
     public var date: Date?
 
     public func setLastProcessedDate(_ date: Date?) {
         self.date = date
+    }
+
+    public static func == (lhs: InMemoryLastProcessedStrategy, rhs: InMemoryLastProcessedStrategy) -> Bool {
+        lhs.date == rhs.date
     }
 }
 

--- a/Sources/OSLogClient/Public/LastProcessedStrategy/LastProcessedStrategy.swift
+++ b/Sources/OSLogClient/Public/LastProcessedStrategy/LastProcessedStrategy.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Enumeration of supported strategies for storing and updating the `Date` the log store was last successfully queried and processed.
-public protocol LastProcessedStrategy {
+public protocol LastProcessedStrategy: Sendable {
     /// The most recent `Date` of a processed/polled log
     var date: Date? { get }
 

--- a/Sources/OSLogClient/Public/LogDriver.swift
+++ b/Sources/OSLogClient/Public/LogDriver.swift
@@ -11,7 +11,7 @@ import OSLog
 /// `LogDriver` instances are responsible for handling processed os logs.
 /// Instances, when registered with the ``OSLogClient`` instance, will be sent logs from the `OSLogStore`.
 /// If  ``LogFilter``s are provided any incoming logs will be assessed against the filter rules and ignored if no matches are found.
-open class LogDriver: Equatable {
+open class LogDriver: Equatable, @unchecked Sendable {
     // MARK: - Supplementary
 
     /// Enumeration of supported log levels.

--- a/Sources/OSLogClient/Public/OSLogClient.swift
+++ b/Sources/OSLogClient/Public/OSLogClient.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_exported import OSLog
+@_exported @preconcurrency import OSLog
 
 /// Class that provides configurable polling of an `OSLogStore`.
 /// Valid log items will be sent to any registered ``LogDriver`` instances.
@@ -26,18 +26,31 @@ import Foundation
 /// - By default polling will not automatically start, once you have finished setting up and registering drivers, you can start and stop
 /// polling by using the ``OSLogClient/startPolling()`` and ``OSLogClient/stopPolling()`` methods.
 ///
-public enum OSLogClient {
+
+public actor OSLogClient {
+
     // MARK: - Internal
 
     /// Internal shared client instance.
-    static var _client: LogClient?
+    static let _client: OSLogClient = OSLogClient(logClient: nil)
 
     /// Convenience getter for non-optional client instance. If the underlying `_client` instance is `nil` then a fatal error will occur.
-    static var client: LogClient {
-        guard let instance = _client else {
+    var logClient: LogClient {
+        guard let instance = _logClient else {
             fatalError("Error: `OSLogClient` not initialized. Please run `OSLogClient.initialize()` before use.")
         }
         return instance
+    }
+
+    /// The underlying log client belonging to the shared instance.
+    /// Note: This is marked as `nonisolated(unsafe)` to avoid an error when getting the immutable `pollingInterval`.
+    /// The instance is used correctly within the OSLogClient setup.
+    var _logClient: LogClient?
+
+    // MARK: - Lifecycle
+
+    init(logClient: LogClient?) {
+        self._logClient = logClient
     }
 
     // MARK: - Public
@@ -48,16 +61,25 @@ public enum OSLogClient {
         pollingInterval: PollingInterval = .medium,
         lastProcessedStrategy: LastProcessedStrategy = .default,
         logStore: OSLogStore? = nil
-    ) throws {
-        guard _client == nil else {
+    ) async throws {
+        guard await _client._logClient == nil else {
             throw OSLogClientError.clientAlreadyInitialized
         }
         do {
             let logStore = try logStore ?? OSLogStore(scope: .currentProcessIdentifier)
-            _client = LogClient(pollingInterval: pollingInterval, lastProcessedStrategy: lastProcessedStrategy, logStore: logStore)
+            let logClient = LogClient(pollingInterval: pollingInterval, lastProcessedStrategy: lastProcessedStrategy, logStore: logStore)
+            await _client.setLogClient(logClient)
         } catch {
             throw OSLogClientError.unableToLoadLogStore(error: error.localizedDescription)
         }
+    }
+
+    // MARK: - Internal
+    
+    /// Internal helper to facilitate isolated mutations and unit testing.
+    /// - Parameter client: The client instance to assign.
+    func setLogClient(_ client: LogClient?) async {
+        _logClient = client
     }
 
     // MARK: - Getters: Immutable Configs
@@ -65,14 +87,16 @@ public enum OSLogClient {
     /// The current polling interval.
     /// - See: ``PollingInterval``
     public static var pollingInterval: PollingInterval {
-        client.pollingInterval
+        get async {
+            await _client.logClient.pollingInterval
+        }
     }
 
     /// The strategy being used when loading, updating, and working with the last processed date.
     /// - See: ``LastProcessedStrategy``
     public static var lastProcessedStrategy: any LastProcessedStrategy {
         get async {
-            await client.lastProcessedStrategy
+            await _client.logClient.lastProcessedStrategy
         }
     }
 
@@ -81,7 +105,7 @@ public enum OSLogClient {
     /// Bool whether polling is currently enabled or not.
     public static var isEnabled: Bool {
         get async {
-            await client.isEnabled
+            await _client.logClient.isEnabled
         }
     }
 
@@ -92,14 +116,14 @@ public enum OSLogClient {
     /// - Note: Default is `true`
     public static var shouldPauseIfNoRegisteredDrivers: Bool {
         get async {
-            await client.shouldPauseIfNoRegisteredDrivers
+            await _client.logClient.shouldPauseIfNoRegisteredDrivers
         }
     }
 
     /// The most recent date-time that the log store was successfully queried and processed.
     public static var lastProcessedDate: Date? {
         get async {
-            await client.lastProcessedDate
+            await _client.logClient.lastProcessedDate
         }
     }
 
@@ -107,19 +131,21 @@ public enum OSLogClient {
 
     /// Returns `false` when the ``OSLogClient/initialize(pollingInterval:logStore:)`` method **has not been invoked**
     public static var isInitialized: Bool {
-        _client != nil
+        get async {
+            await _client._logClient != nil
+        }
     }
 
     // MARK: - Helpers: Polling
 
     /// Will start polling logs at the assigned interval.
     public static func startPolling() async {
-        await client.startPolling()
+        await _client.logClient.startPolling()
     }
 
     /// Will stop polling logs.
     public static func stopPolling() async {
-        await client.stopPolling()
+        await _client.logClient.stopPolling()
     }
 
     /// Will update the time between polls to the given interval.
@@ -131,23 +157,22 @@ public enum OSLogClient {
     /// - SeeAlso: ``PollingInterval``
     public static func setPollingInterval(_ interval: PollingInterval) async {
         // Resolve current settings
-        let currentIsEnabled = await client.isEnabled
+        let currentIsEnabled = await _client.logClient.isEnabled
         // Build new client instance
-        let newClient = await LogClient(
+        let newLogClient = await LogClient(
             pollingInterval: interval,
-            drivers: client.drivers,
-            lastProcessedStrategy: client.lastProcessedStrategy,
-            logStore: client.logStore,
-            logger: client.logger,
-            processInfoEnvironmentProvider: client.processInfoEnvironmentProvider
+            drivers: _client.logClient.drivers,
+            lastProcessedStrategy: _client.logClient.lastProcessedStrategy,
+            logStore: _client.logClient.logStore,
+            logger: _client.logClient.logger,
+            processInfoEnvironmentProvider: _client.logClient.processInfoEnvironmentProvider
         )
         // Assign non-isolated
-        await newClient.setShouldPauseIfNoRegisteredDrivers(client.shouldPauseIfNoRegisteredDrivers)
-        // Assign new shared client
-        _client = newClient
+        await newLogClient.setShouldPauseIfNoRegisteredDrivers(_client.logClient.shouldPauseIfNoRegisteredDrivers)
+        await _client.setLogClient(newLogClient)
         // Enable if was enabled previously
         if currentIsEnabled {
-            await newClient.startPolling()
+            await newLogClient.startPolling()
         }
     }
 
@@ -157,7 +182,7 @@ public enum OSLogClient {
     /// **Note:** This does not reset, delay, or otherwise alter the current polling interval (or scheduled tasks)
     /// - Parameter date: Optional date to query from. Leave `nil` to query from the last time logs were polled (default behaviour).
     public static func pollImmediately(from date: Date? = nil) async {
-        await client.pollLatestLogs(from: date)
+        await _client.logClient.pollLatestLogs(from: date)
     }
 
     // MARK: - Helpers: Drivers
@@ -167,7 +192,7 @@ public enum OSLogClient {
     /// **Note:** The client will hold a strong reference to the driver instance.
     /// - Parameter driver: The driver to register
     public static func registerDriver(_ driver: LogDriver) async {
-        await client.registerDriver(driver)
+        await _client.logClient.registerDriver(driver)
     }
 
     /// Will register the given array of driver instances to receive any polled logs.
@@ -183,14 +208,14 @@ public enum OSLogClient {
     /// Will deregister the driver with the given identifier from receiving an logs.
     /// - Parameter id: The id of the driver to deregister.
     public static func deregisterDriver(withId id: String) async {
-        await client.deregisterDriver(withId: id)
+        await _client.logClient.deregisterDriver(withId: id)
     }
 
     /// Indicates whether a driver with a specified identifier is registered.
     /// - Parameter id: The id of the driver.
     /// - Returns: A `Bool` indicating whether the a driver with the specified identifier is registered.
     public static func isDriverRegistered(withId id: String) async -> Bool {
-        await client.isDriverRegistered(withId: id)
+        await _client.logClient.isDriverRegistered(withId: id)
     }
 
     /// Will assign the given Bool flag to the ``OSLogClient/shouldPauseIfNoRegisteredDrivers`` property.
@@ -198,7 +223,7 @@ public enum OSLogClient {
     /// - Note: When `true` if all drivers are deregistered, polling will cease until valid drivers are registered again.
     /// - Parameter flag: Bool whether enabled.
     public static func setShouldPauseIfNoRegisteredDrivers(_ flag: Bool) async {
-        await client.setShouldPauseIfNoRegisteredDrivers(flag)
+        await _client.logClient.setShouldPauseIfNoRegisteredDrivers(flag)
     }
 
     // MARK: - Deprecated
@@ -207,7 +232,7 @@ public enum OSLogClient {
     @available(*, deprecated, renamed: "lastProcessedDate", message: "`lastPolledDate` was an inaccurate name. Please use `lastProcessedDate`")
     public static var lastPolledDate: Date? {
         get async {
-            await client.lastProcessedDate
+            await _client.logClient.lastProcessedDate
         }
     }
 
@@ -215,7 +240,7 @@ public enum OSLogClient {
     @available(*, deprecated, renamed: "isEnabled", message: "`isPolling` has been renamed. Please use `isEnabled` insread")
     public static var isPolling: Bool {
         get async {
-            await client.isEnabled
+            await _client.logClient.isEnabled
         }
     }
 }

--- a/Sources/OSLogClient/Public/PollingInterval.swift
+++ b/Sources/OSLogClient/Public/PollingInterval.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Enumeration of supported polling interval options.
-public enum PollingInterval: Equatable {
+public enum PollingInterval: Equatable, Sendable {
     /// Represents an interval of 10 seconds
     case short
     /// Represents an interval of 30 seconds

--- a/Tests/OSLogClientTests/Public/LogClientTests.swift
+++ b/Tests/OSLogClientTests/Public/LogClientTests.swift
@@ -6,7 +6,9 @@
 //
 
 import XCTest
-@testable import OSLogClient
+@testable @preconcurrency import OSLogClient
+
+extension OSLogStore: @unchecked @retroactive Sendable {}
 
 final class LogClientTests: XCTestCase {
 

--- a/Tests/OSLogClientTests/Utils/Mocks/LogDriverSpy.swift
+++ b/Tests/OSLogClientTests/Utils/Mocks/LogDriverSpy.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 @testable import OSLogClient
 
-class LogDriverSpy: LogDriver {
+class LogDriverSpy: LogDriver, @unchecked Sendable {
 #if os(macOS)
     typealias ProcessLogParameters = (
         level: LogDriver.LogLevel,

--- a/Tests/OSLogClientTests/Utils/TestProcessInfoProvider.swift
+++ b/Tests/OSLogClientTests/Utils/TestProcessInfoProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 @testable import OSLogClient
 
 /// `ProcessInfoEnvironmentProvider` instance that injects a run-time unit-test driven argument for facilitating some unit tests.
-class TestProcessInfoProvider: ProcessInfoEnvironmentProvider {
+class TestProcessInfoProvider: ProcessInfoEnvironmentProvider, @unchecked Sendable {
 
     var processInfoEnvironment: [String : String] {
         var base = ProcessInfo.processInfo.environment


### PR DESCRIPTION
- Adds dedicated package manifest files for Swift 6
- Adds required Sendable support
- Marks some OSLogStore related elements with pre concurrency and retroactive (for testing purposes)
- `OSLogClient.pollingInterval` now requires `async`
- Updated shared instance structure to better support concurrency